### PR TITLE
Add failure cache and fallback logger for TelemetryClient

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.1.x-dev"
+            "dev-master": "0.2.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,9 @@
     },
     "require": {
         "php": "^7.1",
-        "microsoft/application-insights": "^0.4.5"
+        "microsoft/application-insights": "^0.4.5",
+        "psr/simple-cache": "^1.0",
+        "psr/log": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0 || ^8.0"

--- a/src/AppInsightsPHP/Client/Client.php
+++ b/src/AppInsightsPHP/Client/Client.php
@@ -51,6 +51,10 @@ final class Client
 
     public function flush(): void
     {
+        if (!$this->configuration->isEnabled()) {
+            return ;
+        }
+
         try {
             if ($this->failureCache && $this->failureCache->has(self::CACHE_CHANNEL_KEY)) {
                 $this->client->getChannel()->setQueue(

--- a/src/AppInsightsPHP/Client/Client.php
+++ b/src/AppInsightsPHP/Client/Client.php
@@ -5,6 +5,8 @@ declare (strict_types=1);
 namespace AppInsightsPHP\Client;
 
 use ApplicationInsights\Telemetry_Client;
+use Psr\Log\LoggerInterface;
+use Psr\SimpleCache\CacheInterface;
 
 /**
  * @method \ApplicationInsights\Telemetry_Context getContext()
@@ -19,22 +21,68 @@ use ApplicationInsights\Telemetry_Client;
  * @method void endRequest(\ApplicationInsights\Channel\Contracts\Request_Data $request, $durationInMilliseconds = 0, $httpResponseCode = 200, $isSuccessful = true, $properties = NULL, $measurements = NULL)
  * @method void trackException($ex, $properties = NULL, $measurements = NULL)
  * @method void trackDependency($name,$type = "",$commandName = NULL,$startTime = NULL,$durationInMilliseconds = 0,$isSuccessful = true,$resultCode = NULL,$properties = NULL)
- * @method void flush($options = array(), $sendAsync = false)
  */
 final class Client
 {
+    public const CACHE_CHANNEL_KEY = 'app_insights_php.failure_cache';
+    public const CACHE_CHANNEL_TTL_SEC = 86400; // 1 day
+
     private $client;
     private $configuration;
+    private $failureCache;
+    private $fallbackLogger;
 
-    public function __construct(Telemetry_Client $client, Configuration $configuration)
-    {
+    public function __construct(
+        Telemetry_Client $client,
+        Configuration $configuration,
+        CacheInterface $failureCache = null,
+        LoggerInterface $fallbackLogger = null
+    ) {
         $this->client = $client;
         $this->configuration = $configuration;
+        $this->failureCache = $failureCache;
+        $this->fallbackLogger = $fallbackLogger;
     }
 
     public function configuration(): Configuration
     {
         return $this->configuration;
+    }
+
+    public function flush(): void
+    {
+        try {
+            if ($this->failureCache && $this->failureCache->has(self::CACHE_CHANNEL_KEY)) {
+                $this->client->getChannel()->setQueue(
+                    array_merge(
+                        unserialize($this->failureCache->get(self::CACHE_CHANNEL_KEY)),
+                        $this->client->getChannel()->getQueue()
+                    )
+                );
+
+                $this->failureCache->delete(self::CACHE_CHANNEL_KEY);
+            }
+
+            $this->client->flush();
+        } catch (\Throwable $e) {
+            if ($this->failureCache) {
+                $queueContent = $this->client->getChannel()->getQueue();
+
+                if ($this->failureCache->has(self::CACHE_CHANNEL_KEY)) {
+                    $previousQueueContent = unserialize($this->failureCache->get(self::CACHE_CHANNEL_KEY));
+                    $queueContent = array_merge($previousQueueContent, $queueContent);
+                }
+
+                $this->failureCache->set(self::CACHE_CHANNEL_KEY, serialize($queueContent), self::CACHE_CHANNEL_TTL_SEC);
+            }
+
+            if ($this->fallbackLogger) {
+                $this->fallbackLogger->error(
+                    sprintf('Exception occurred while flushing App Insights Telemetry Client: %s', $e->getMessage()),
+                    json_decode($this->client->getChannel()->getSerializedQueue(), true)
+                );
+            }
+        }
     }
 
     public function __call($name, $arguments)

--- a/src/AppInsightsPHP/Client/ClientFactory.php
+++ b/src/AppInsightsPHP/Client/ClientFactory.php
@@ -5,16 +5,26 @@ declare (strict_types=1);
 namespace AppInsightsPHP\Client;
 
 use ApplicationInsights\Telemetry_Client;
+use Psr\Log\LoggerInterface;
+use Psr\SimpleCache\CacheInterface;
 
 final class ClientFactory implements ClientFactoryInterface
 {
     private $instrumentationKey;
     private $configuration;
+    private $failureCache;
+    private $fallbackLogger;
 
-    public function __construct(string $instrumentationKey, Configuration $configuration)
-    {
+    public function __construct(
+        string $instrumentationKey,
+        Configuration $configuration,
+        CacheInterface $failureCache = null,
+        LoggerInterface $fallbackLogger = null
+    ) {
         $this->instrumentationKey = $instrumentationKey;
         $this->configuration = $configuration;
+        $this->failureCache = $failureCache;
+        $this->fallbackLogger = $fallbackLogger;
     }
 
     public function create() : Client
@@ -22,6 +32,11 @@ final class ClientFactory implements ClientFactoryInterface
         $client = new Telemetry_Client();
         $client->getContext()->setInstrumentationKey($this->instrumentationKey);
 
-        return new Client($client, $this->configuration);
+        return new Client(
+            $client,
+            $this->configuration,
+            $this->failureCache,
+            $this->fallbackLogger
+        );
     }
 }

--- a/tests/AppInsightsPHP/Client/Tests/ClientTest.php
+++ b/tests/AppInsightsPHP/Client/Tests/ClientTest.php
@@ -224,6 +224,20 @@ final class ClientTest extends TestCase
         $client->trackMessage('message');
     }
 
+    public function test_flushing_when_client_is_disabled()
+    {
+        $configuration = Configuration::createDefault();
+        $configuration->disable();
+
+        $telemetryMock = $this->createMock(Telemetry_Client::class);
+        $this->givenTelemetryChannelIsNotEmpty($telemetryMock);
+
+        $telemetryMock->expects($this->never())->method('flush');
+
+        $client = new Client($telemetryMock, $configuration);
+        $client->flush();
+    }
+
     public function test_fallback_logger_during_flush_unexpected_exception()
     {
         $telemetryMock = $this->createMock(Telemetry_Client::class);

--- a/tests/AppInsightsPHP/Client/Tests/ClientTest.php
+++ b/tests/AppInsightsPHP/Client/Tests/ClientTest.php
@@ -7,8 +7,12 @@ namespace AppInsightsPHP\Client\Tests;
 use AppInsightsPHP\Client\Client;
 use AppInsightsPHP\Client\Configuration;
 use ApplicationInsights\Channel\Contracts\Request_Data;
+use ApplicationInsights\Channel\Telemetry_Channel;
 use ApplicationInsights\Telemetry_Client;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\SimpleCache\CacheInterface;
 
 final class ClientTest extends TestCase
 {
@@ -187,7 +191,6 @@ final class ClientTest extends TestCase
         $client->trackException(new \RuntimeException());
     }
 
-
     public function test_tracking_traces_when_option_is_enabled()
     {
         $telemetryMock = $this->createMock(Telemetry_Client::class);
@@ -219,5 +222,91 @@ final class ClientTest extends TestCase
             ->method('trackMessage');
 
         $client->trackMessage('message');
+    }
+
+    public function test_fallback_logger_during_flush_unexpected_exception()
+    {
+        $telemetryMock = $this->createMock(Telemetry_Client::class);
+        $loggerMock = $this->createMock(LoggerInterface::class);
+
+        $this->givenTelemetryChannelIsNotEmpty($telemetryMock);
+        $telemetryMock->method('flush')->willThrowException(new \RuntimeException('Unexpected API exception'));
+
+        $loggerMock->expects($this->once())
+            ->method('error')
+            ->with('Exception occurred while flushing App Insights Telemetry Client: Unexpected API exception');
+
+        $client = new Client($telemetryMock, Configuration::createDefault(), null, $loggerMock);
+        $client->flush();
+    }
+
+    public function test_adding_queue_to_failure_cache_on_unexpected_api_exception_and_cache_is_empty()
+    {
+        $telemetryMock = $this->createMock(Telemetry_Client::class);
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $cacheMock = $this->createMock(CacheInterface::class);
+
+        $this->givenTelemetryChannelIsNotEmpty($telemetryMock);
+        $telemetryMock->method('flush')->willThrowException(new \RuntimeException('Unexpected API exception'));
+        $cacheMock->method('has')->willReturn(false);
+
+        $cacheMock->expects($this->once())
+            ->method('set')
+            ->with(Client::CACHE_CHANNEL_KEY, serialize(['some_log_entry']), Client::CACHE_CHANNEL_TTL_SEC);
+
+        $client = new Client($telemetryMock, Configuration::createDefault(), $cacheMock, $loggerMock);
+        $client->flush();
+    }
+
+    public function test_adding_queue_to_failure_cache_on_unexpected_api_exception_and_cache_is_not_empty()
+    {
+        $telemetryMock = $this->createMock(Telemetry_Client::class);
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $cacheMock = $this->createMock(CacheInterface::class);
+
+        $this->givenTelemetryChannelIsNotEmpty($telemetryMock);
+        $telemetryMock->method('flush')->willThrowException(new \RuntimeException('Unexpected API exception'));
+        $cacheMock->method('has')->willReturn(true);
+        $cacheMock->method('get')->willReturn(serialize(['some_older_entry']));
+
+        $cacheMock->expects($this->once())
+            ->method('set')
+            ->with(Client::CACHE_CHANNEL_KEY, serialize(['some_older_entry', 'some_log_entry']), Client::CACHE_CHANNEL_TTL_SEC);
+
+        $client = new Client($telemetryMock, Configuration::createDefault(), $cacheMock, $loggerMock);
+        $client->flush();
+    }
+
+    public function test_flush_when_cache_is_not_empty()
+    {
+        $telemetryMock = $this->createMock(Telemetry_Client::class);
+        $loggerMock = $this->createMock(LoggerInterface::class);
+        $cacheMock = $this->createMock(CacheInterface::class);
+
+        $telemetryChannelMock = $this->givenTelemetryChannelIsNotEmpty($telemetryMock);
+        $cacheMock->method('has')->willReturn(true);
+        $cacheMock->method('get')->willReturn(serialize(['some_older_entry']));
+
+        $cacheMock->expects($this->once())
+            ->method('delete')
+            ->with(Client::CACHE_CHANNEL_KEY);
+
+        $telemetryChannelMock->expects($this->once())
+            ->method('setQueue')
+            ->with(['some_older_entry', 'some_log_entry']);
+
+        $telemetryMock->expects($this->once())->method('flush');
+
+        $client = new Client($telemetryMock, Configuration::createDefault(), $cacheMock, $loggerMock);
+        $client->flush();
+    }
+
+    private function givenTelemetryChannelIsNotEmpty(MockObject $telemetryMock): MockObject
+    {
+        $telemetryMock->method('getChannel')->willReturn($telemetryChannelMock = $this->createMock(Telemetry_Channel::class));
+        $telemetryChannelMock->method('getQueue')->willReturn(['some_log_entry']);
+        $telemetryChannelMock->method('getSerializedQueue')->willReturn(json_encode(['some_log_entry']));
+
+        return $telemetryChannelMock;
     }
 }


### PR DESCRIPTION
It was moved from https://github.com/app-insights-php/app-insights-php-bundle/pull/18/