### PR TITLE
Remove fallback logger from the Client and rethrow the exception on failure

### DIFF
--- a/src/AppInsightsPHP/Client/ClientFactory.php
+++ b/src/AppInsightsPHP/Client/ClientFactory.php
@@ -5,7 +5,6 @@ declare (strict_types=1);
 namespace AppInsightsPHP\Client;
 
 use ApplicationInsights\Telemetry_Client;
-use Psr\Log\LoggerInterface;
 use Psr\SimpleCache\CacheInterface;
 
 final class ClientFactory implements ClientFactoryInterface
@@ -13,18 +12,15 @@ final class ClientFactory implements ClientFactoryInterface
     private $instrumentationKey;
     private $configuration;
     private $failureCache;
-    private $fallbackLogger;
 
     public function __construct(
         string $instrumentationKey,
         Configuration $configuration,
-        CacheInterface $failureCache = null,
-        LoggerInterface $fallbackLogger = null
+        CacheInterface $failureCache = null
     ) {
         $this->instrumentationKey = $instrumentationKey;
         $this->configuration = $configuration;
         $this->failureCache = $failureCache;
-        $this->fallbackLogger = $fallbackLogger;
     }
 
     public function create() : Client
@@ -35,8 +31,7 @@ final class ClientFactory implements ClientFactoryInterface
         return new Client(
             $client,
             $this->configuration,
-            $this->failureCache,
-            $this->fallbackLogger
+            $this->failureCache
         );
     }
 }

--- a/tests/AppInsightsPHP/Client/Tests/ClientTest.php
+++ b/tests/AppInsightsPHP/Client/Tests/ClientTest.php
@@ -238,48 +238,34 @@ final class ClientTest extends TestCase
         $client->flush();
     }
 
-    public function test_fallback_logger_during_flush_unexpected_exception()
-    {
-        $telemetryMock = $this->createMock(Telemetry_Client::class);
-        $loggerMock = $this->createMock(LoggerInterface::class);
-
-        $this->givenTelemetryChannelIsNotEmpty($telemetryMock);
-        $telemetryMock->method('flush')->willThrowException(new \RuntimeException('Unexpected API exception'));
-
-        $loggerMock->expects($this->once())
-            ->method('error')
-            ->with('Exception occurred while flushing App Insights Telemetry Client: Unexpected API exception');
-
-        $client = new Client($telemetryMock, Configuration::createDefault(), null, $loggerMock);
-        $client->flush();
-    }
-
     public function test_adding_queue_to_failure_cache_on_unexpected_api_exception_and_cache_is_empty()
     {
         $telemetryMock = $this->createMock(Telemetry_Client::class);
-        $loggerMock = $this->createMock(LoggerInterface::class);
         $cacheMock = $this->createMock(CacheInterface::class);
+        $exception = new \RuntimeException('Unexpected API exception');
 
         $this->givenTelemetryChannelIsNotEmpty($telemetryMock);
-        $telemetryMock->method('flush')->willThrowException(new \RuntimeException('Unexpected API exception'));
+        $telemetryMock->method('flush')->willThrowException($exception);
         $cacheMock->method('has')->willReturn(false);
 
         $cacheMock->expects($this->once())
             ->method('set')
             ->with(Client::CACHE_CHANNEL_KEY, serialize(['some_log_entry']), Client::CACHE_CHANNEL_TTL_SEC);
 
-        $client = new Client($telemetryMock, Configuration::createDefault(), $cacheMock, $loggerMock);
+        $this->expectExceptionObject($exception);
+
+        $client = new Client($telemetryMock, Configuration::createDefault(), $cacheMock);
         $client->flush();
     }
 
     public function test_adding_queue_to_failure_cache_on_unexpected_api_exception_and_cache_is_not_empty()
     {
         $telemetryMock = $this->createMock(Telemetry_Client::class);
-        $loggerMock = $this->createMock(LoggerInterface::class);
         $cacheMock = $this->createMock(CacheInterface::class);
+        $exception = new \RuntimeException('Unexpected API exception');
 
         $this->givenTelemetryChannelIsNotEmpty($telemetryMock);
-        $telemetryMock->method('flush')->willThrowException(new \RuntimeException('Unexpected API exception'));
+        $telemetryMock->method('flush')->willThrowException($exception);
         $cacheMock->method('has')->willReturn(true);
         $cacheMock->method('get')->willReturn(serialize(['some_older_entry']));
 
@@ -287,7 +273,9 @@ final class ClientTest extends TestCase
             ->method('set')
             ->with(Client::CACHE_CHANNEL_KEY, serialize(['some_older_entry', 'some_log_entry']), Client::CACHE_CHANNEL_TTL_SEC);
 
-        $client = new Client($telemetryMock, Configuration::createDefault(), $cacheMock, $loggerMock);
+        $this->expectExceptionObject($exception);
+
+        $client = new Client($telemetryMock, Configuration::createDefault(), $cacheMock);
         $client->flush();
     }
 


### PR DESCRIPTION
`Client` itself should not handle the exception. It can cache the logs but then it should rethrow the exception. Clients of `TelemetryClient` should do what they need to do when the exception occurs.