### PR TITLE
not add to failures when is to old time in envelope response

### DIFF
--- a/src/AppInsightsPHP/Client/Client.php
+++ b/src/AppInsightsPHP/Client/Client.php
@@ -66,15 +66,17 @@ final class Client
                 try {
                     (new SendOne)($this->client, $item);
                 } catch (\Throwable $e) {
-                    $this->fallbackLogger->error(
-                        sprintf('Exception occurred while flushing App Insights Telemetry Client: %s', $e->getMessage()),
-                        [
-                            'item' => \json_encode($item),
-                            'exception' => $e
-                        ]
-                    );
+                    if (false === ResponseMessage::message($e->getMessage())->isToOldTimeInEnvelope()) {
+                        $this->fallbackLogger->error(
+                            sprintf('Exception occurred while flushing App Insights Telemetry Client: %s', $e->getMessage()),
+                            [
+                                'item' => \json_encode($item),
+                                'exception' => $e
+                            ]
+                        );
 
-                    $failures[] = $item;
+                        $failures[] = $item;
+                    }
                 }
             }
 

--- a/src/AppInsightsPHP/Client/ResponseMessage.php
+++ b/src/AppInsightsPHP/Client/ResponseMessage.php
@@ -1,0 +1,25 @@
+<?php
+
+declare (strict_types=1);
+
+namespace AppInsightsPHP\Client;
+
+final class ResponseMessage
+{
+    private $message;
+
+    private function __construct(string $message)
+    {
+        $this->message = $message;
+    }
+
+    public static function message(string $message): self
+    {
+        return new self($message);
+    }
+
+    public function isToOldTimeInEnvelope(): bool
+    {
+        return false !== \strpos($this->message, "Field 'time' on type 'Envelope' is older than the allowed min date.");
+    }
+}

--- a/tests/AppInsightsPHP/Client/Tests/ResponseMessageTest.php
+++ b/tests/AppInsightsPHP/Client/Tests/ResponseMessageTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare (strict_types=1);
+
+namespace AppInsightsPHP\Client\Tests;
+
+use AppInsightsPHP\Client\ResponseMessage;
+use PHPUnit\Framework\TestCase;
+
+final class ResponseMessageTest extends TestCase
+{
+    public function test_message_contain_is_to_old_time_envelope_string(): void
+    {
+        $this->assertTrue(
+            ResponseMessage::message("Test if this message contain: Field 'time' on type 'Envelope' is older than the allowed min date. Test some post string...")
+                ->isToOldTimeInEnvelope()
+        );
+    }
+
+    /**
+     * @dataProvider invalid
+     */
+    public function test_message_not_contain_is_to_old_time_envelope_string(string $message): void
+    {
+        $this->assertFalse(
+            ResponseMessage::message($message)
+                ->isToOldTimeInEnvelope()
+        );
+    }
+
+    public function invalid(): \Generator
+    {
+        yield ["Field 'time' on type 'Envelope' is older than the allowed"];
+        yield [\uniqid('test-string-')];
+        yield ["field 'time' on type 'Envelope' is older than the allowed min date."];
+    }
+}


### PR DESCRIPTION
I added a method to parse an `errorMessage` from exceptions. It is necessary, because previously if we get http code `400` and validation error for `time` field in `Envelope` object. Then we add this invalid `item` to retry queue and again we are getting another `400`... 

Now when exception have `Field 'time' on type 'Envelope' is older than the allowed min date.` string in message code will skip it.