### PR TITLE
do not unserialize when cache is empty

### DIFF
--- a/src/AppInsightsPHP/Client/FailureCache.php
+++ b/src/AppInsightsPHP/Client/FailureCache.php
@@ -23,7 +23,7 @@ final class FailureCache
     {
         if ($this->cache->has(self::CACHE_CHANNEL_KEY)) {
             $envelopes = \array_merge(
-                unserialize($this->cache->get(self::CACHE_CHANNEL_KEY)),
+                $this->all(),
                 $envelopes
             );
         }
@@ -38,11 +38,13 @@ final class FailureCache
 
     public function all(): array
     {
-        if ($this->cache->has(self::CACHE_CHANNEL_KEY)) {
-            return unserialize($this->cache->get(self::CACHE_CHANNEL_KEY));
+        $cacheData = $this->cache->get(self::CACHE_CHANNEL_KEY);
+
+        if (null === $cacheData) {
+            return [];
         }
 
-        return [];
+        return unserialize($cacheData);
     }
 
     public function empty(): bool

--- a/tests/AppInsightsPHP/Client/Tests/FailureCacheTest.php
+++ b/tests/AppInsightsPHP/Client/Tests/FailureCacheTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AppInsightsPHP\Client\Tests;
 
 use AppInsightsPHP\Client\FailureCache;
+use AppInsightsPHP\Client\Tests\Fake\FakeCache;
 use ApplicationInsights\Channel\Contracts\Envelope;
 use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\CacheInterface;
@@ -36,5 +37,13 @@ final class FailureCacheTest extends TestCase
 
         $failureCache = new FailureCache($cacheMock);
         $failureCache->add(new Envelope());
+    }
+
+    public function test_all_when_cache_is_empty()
+    {
+        $failureCache = new FailureCache($cache = new FakeCache());
+
+        $this->assertEmpty($failureCache->all());
+        $this->assertTrue($failureCache->empty());
     }
 }

--- a/tests/AppInsightsPHP/Client/Tests/Fake/FakeCache.php
+++ b/tests/AppInsightsPHP/Client/Tests/Fake/FakeCache.php
@@ -10,9 +10,9 @@ final class FakeCache implements CacheInterface
 {
     private $cache = [];
 
-    public function get($key, $default = null): string
+    public function get($key, $default = null): ?string
     {
-        return $this->cache[$key];
+        return $this->cache[$key] ?? $default;
     }
 
     public function set($key, $value, $ttl = null): void


### PR DESCRIPTION
Used `CacheInterface` said:

![image](https://user-images.githubusercontent.com/40394783/72980286-97f80480-3dda-11ea-9fa0-faaa74fe7fe6.png)

So i want to use `get` instead of `has`, because i wan to load data to variable and then decide what i should to do.

![image](https://user-images.githubusercontent.com/40394783/72980437-e0afbd80-3dda-11ea-9c45-160ad7eb6845.png)

If cache is empty `get` returns `null` by default