### PR TITLE
Accept null on endRequest if module disabled

### DIFF
--- a/src/AppInsightsPHP/Client/Client.php
+++ b/src/AppInsightsPHP/Client/Client.php
@@ -162,7 +162,7 @@ final class Client
         return $this->client->beginRequest($name, $url, $startTime);
     }
 
-    public function endRequest(Request_Data $request, int $durationInMilliseconds = 0, int $httpResponseCode = 200, bool $isSuccessful = true, array $properties = NULL, array $measurements = NULL): void
+    public function endRequest(?Request_Data $request, int $durationInMilliseconds = 0, int $httpResponseCode = 200, bool $isSuccessful = true, array $properties = NULL, array $measurements = NULL): void
     {
         if (!$this->configuration->isEnabled() || !$this->configuration->requests()->isEnabled()) {
             return;


### PR DESCRIPTION
If the module is disabled in the configuration, no request is created. Hence Client->endRequest() has to accept null instead of the non-existant request. Compatible with PHP7.1+