### PR TITLE
Bumped app-insights-php/application-insights to 4.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": "^7.3 || ~8.0 || ~8.1",
-        "app-insights-php/application-insights": "^0.4.6",
+        "app-insights-php/application-insights": "^0.4.7",
         "guzzlehttp/guzzle": "^6.0",
         "psr/simple-cache": "^1.0",
         "psr/log": "^1.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b447c9e8a58364a524c9cb5c1900eac4",
+    "content-hash": "7caf2c15582338a539ec592955e68da2",
     "packages": [
         {
             "name": "app-insights-php/application-insights",
-            "version": "0.4.6",
+            "version": "0.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/app-insights-php/applicationInsights-php.git",
-                "reference": "d55da7bc4139da62b915570f9aff699d20a42fd1"
+                "reference": "738328cc6f9f54e59f7aa7be53783e4cf5ff63b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/app-insights-php/applicationInsights-php/zipball/d55da7bc4139da62b915570f9aff699d20a42fd1",
-                "reference": "d55da7bc4139da62b915570f9aff699d20a42fd1",
+                "url": "https://api.github.com/repos/app-insights-php/applicationInsights-php/zipball/738328cc6f9f54e59f7aa7be53783e4cf5ff63b7",
+                "reference": "738328cc6f9f54e59f7aa7be53783e4cf5ff63b7",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/guzzle": ">=5.0 <=6.3.3",
+                "guzzlehttp/guzzle": ">=5.0 <=7.4.4",
                 "php": "^7.4.0 || ~8.0 || ~8.1"
             },
             "type": "library",
@@ -44,9 +44,9 @@
                 "telemetry"
             ],
             "support": {
-                "source": "https://github.com/app-insights-php/applicationInsights-php/tree/0.4.6"
+                "source": "https://github.com/app-insights-php/applicationInsights-php/tree/0.4.7"
             },
-            "time": "2022-04-15T12:16:42+00:00"
+            "time": "2022-05-26T12:07:10+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -4669,5 +4669,5 @@
         "php": "^7.3 || ~8.0 || ~8.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Required version of app-insights-php/application-insights to 4.7</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

This is related to Guzzle vulnerability https://github.com/guzzle/guzzle/security/advisories/GHSA-cwmx-hcrq-mhc3